### PR TITLE
debug: addon output flags

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -11,28 +11,78 @@ function debug::__failure() {
 trap 'debug::__failure ${LINENO} "$BASH_COMMAND"' ERR
 
 function debug::__aggregate_interceptor_queue() {
-jq -n '
-  reduce inputs as $in ({}; 
-    reduce ($in | to_entries[]) as $entry (.;
-      .[$entry.key] as $existing |
-      if $existing then
-        .[$entry.key] = (
-          $existing | 
-          with_entries(
-            .value as $v | 
-            $entry.value[.key] as $new_val |
-            if $new_val then
-              .value = ($v + $new_val)
+    local output_type="$1"
+    local mode="$2"
+
+    local cmd=""
+    case $output_type in
+        json)
+            cmd="jq '.'"
+            ;;
+        yaml)
+            cmd="yq e -P"
+            ;;
+        *)
+            cmd="$(debug::__addon_queue_structured_output $mode) | column -t -s $'\t'"
+            ;;            
+    esac
+    jq -n --arg mode "$mode" '
+      if $mode == "aggregated" then
+        # Aggregate all queues (original behavior)
+        reduce inputs as $in ({};
+          reduce ($in.queue | to_entries[]) as $entry (.;
+            .[$entry.key] as $existing |
+            if $existing then
+              .[$entry.key] = (
+                $existing |
+                with_entries(
+                  .value as $v |
+                  $entry.value[.key] as $new_val |
+                  if $new_val then
+                    .value = ($v + $new_val)
+                  else
+                    .
+                  end
+                )
+              )
             else
-              .
+              .[$entry.key] = $entry.value
             end
           )
         )
       else
-        .[$entry.key] = $entry.value
+        # Individual mode: preserve pod names
+        [inputs | {pod: .name, queue: .queue}]
       end
-    )
-  )'
+    ' | eval "$cmd"
+}
+
+function debug::__addon_queue_structured_output() {
+    local mode="$1"
+    if [ "$mode" = "individual" ]; then
+        cat <<'EOF'
+jq -r '
+(["POD", "TARGET", "CONCURRENCY", "RPS"],
+ (.[] | [
+    .pod,
+    (.queue | keys[0]),
+    .queue[.queue | keys[0]].Concurrency,
+    .queue[.queue | keys[0]].RPS
+ ]))
+ | @tsv'
+EOF
+    else
+        cat <<'EOF'
+jq -r '
+(["TARGET", "CONCURRENCY", "RPS"],
+ (to_entries[] | [
+    .key,
+    .value.Concurrency,
+    .value.RPS
+ ]))
+ | @tsv'
+EOF
+    fi
 }
 
 function debug::__print_usage() {
@@ -72,25 +122,59 @@ EOF
 }
 
 function debug::__httpaddon_cmd() {
-   local sub_command="$1"
-   local ns=""
-   if kubectl get kedify -A > /dev/null 2>&1; then
-       ns=$(kubectl get kedify -A -o json | jq -r '.items[0].metadata.namespace')
-   fi
-   case $sub_command in
-       queue)
-           (kubectl get pods -l app.kubernetes.io/name=http-add-on -l app.kubernetes.io/component=interceptor -n "$ns" -o json | jq -r '.items[].metadata.name' | while read -r pod; do
-               local q=$(kubectl get --raw "/api/v1/namespaces/$ns/pods/$pod/proxy/queue")
-               >&2 echo "$pod: $q"
-               echo "$q"
-           done) | debug::__aggregate_interceptor_queue
-           ;;
-       *)
-           echo "Unknown sub-command: \"$sub_command\""
-           debug::__print_usage
-           exit 1
-           ;;
-   esac
+    local sub_command="$1"
+    shift
+
+    local ns=""
+    if kubectl get kedify -A > /dev/null 2>&1; then
+        ns=$(kubectl get kedify -A -o json | jq -r '.items[0].metadata.namespace')
+    fi
+    local output_type=""
+    local mode="aggregated"
+    local next="false"
+    for o in "$@"; do
+        if [[ "$next" == "true" ]]; then
+            output_type="$o"
+            next="false"
+            continue
+        fi
+        case $o in
+            -o|--output)
+                next="true"
+                ;;
+            -o=*|--output=*)
+                output_type="${o#*=}"
+                ;;
+            -o*)
+                output_type="${o#-o}"
+                ;;
+            --output*)
+                output_type="${o#--output}"
+                ;;
+            -i|--individual)
+                mode="individual"
+                ;;
+            *)
+                echo "Unknown flag: $o"
+                echo "" 
+                echo "Available flags:"
+                echo "  -o|--output         ... output format (json, yaml)"
+                echo "  -i|--individual     ... show individual queue sizes per interceptor instead of aggregating"
+                debug::__print_usage
+        esac
+    done
+    case $sub_command in
+        queue)
+            kubectl get pods -l app.kubernetes.io/name=http-add-on -l app.kubernetes.io/component=interceptor -n "$ns" -o json | jq -r '.items[].metadata.name' | while read -r pod; do
+                kubectl get --raw "/api/v1/namespaces/$ns/pods/$pod/proxy/queue" | jq -r '. | {name: "'$pod'", queue: .}'
+            done | debug::__aggregate_interceptor_queue "$output_type" "$mode"
+            ;;
+        *)
+            echo "Unknown sub-command: \"$sub_command\""
+            debug::__print_usage
+            exit 1
+            ;;
+    esac
 }
 
 function debug::__dump_cmd() {


### PR DESCRIPTION
adding support for a few flags on the addon queue subcommand enhancing https://github.com/kedify/kubectl-kedify/pull/17

* `-o|--output` - when not present prints human readable columns, alternatively supports `json` and `yaml`
* `-i|--individual` - by default, all queues from all interceptor replicas are aggregated, this flag supports printing each individual queue for each interceptor

<details>
<summary>1) example with plaintext aggregated</summary>

```
$ kubectl kedify debug httpaddon queue
TARGET               CONCURRENCY  RPS
default/http-server  0            50
```

</details>

<details>
<summary>2) example with plaintext not aggregated</summary>

```
$ httpaddon kedify debug httpaddon queue --individual
POD                                             TARGET               CONCURRENCY  RPS
keda-add-ons-http-interceptor-567f8cc77b-c64fs  default/http-server  0            18
keda-add-ons-http-interceptor-567f8cc77b-cgk6r  default/http-server  0            8
keda-add-ons-http-interceptor-567f8cc77b-f8956  default/http-server  0            13
keda-add-ons-http-interceptor-567f8cc77b-tm5nd  default/http-server  0            22
keda-add-ons-http-interceptor-567f8cc77b-ztxdv  default/http-server  0            16
```

</details>

<details>
<summary>3) example with json not aggregated</summary>

```
$ httpaddon kedify debug httpaddon queue --individual -o json
[
  {
    "pod": "keda-add-ons-http-interceptor-567f8cc77b-c64fs",
    "queue": {
      "default/http-server": {
        "Concurrency": 0,
        "RPS": 8
      }
    }
  },
  {
    "pod": "keda-add-ons-http-interceptor-567f8cc77b-cgk6r",
    "queue": {
      "default/http-server": {
        "Concurrency": 0,
        "RPS": 7
      }
    }
  },
  {
    "pod": "keda-add-ons-http-interceptor-567f8cc77b-f8956",
    "queue": {
      "default/http-server": {
        "Concurrency": 0,
        "RPS": 6
      }
    }
  },
  {
    "pod": "keda-add-ons-http-interceptor-567f8cc77b-tm5nd",
    "queue": {
      "default/http-server": {
        "Concurrency": 0,
        "RPS": 5
      }
    }
  },
  {
    "pod": "keda-add-ons-http-interceptor-567f8cc77b-ztxdv",
    "queue": {
      "default/http-server": {
        "Concurrency": 0,
        "RPS": 14
      }
    }
  }
]
```

</summary>