### PR TITLE
fix helper script paths

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -122,6 +122,13 @@ EOF
 }
 
 function debug::__httpaddon_cmd() {
+    if [[ $# -eq 0 ]]; then
+        echo "No sub-command provided, available sub-commands are:"
+        echo "  queue"
+        echo ""
+        debug::__print_usage
+        exit 1
+    fi
     local sub_command="$1"
     shift
 

--- a/kubectl-kedify
+++ b/kubectl-kedify
@@ -10,7 +10,10 @@ TEMPLATE_FILE=${TEMPLATE_FILE:-"hso.yaml"}
 export COL="\e[2;35;49m"
 export RES="\e[0m"
 
-source ./${DIR}/debug.sh
+STORE_PATH=$(kubectl krew version | awk '/InstallPath/{print($2)}')/kedify/
+KEDIFY_VERSION=$(ls $STORE_PATH | head -n1)
+
+source "${STORE_PATH}/${KEDIFY_VERSION}/debug.sh"
 
 main() {
     [[ $# -lt 1 ]] && print_usage && exit 1


### PR DESCRIPTION
the `${KREW_DIR}/bin` contains only the plugin entrypoint, all helper scripts are in `InstallPath`, which is `${KREW_DIR}/store/kedify/${PLUGIN_VERSION}`.