### PR TITLE
fix: insights arithmetic exit code

### DIFF
--- a/insights.sh
+++ b/insights.sh
@@ -282,7 +282,7 @@ insights_analyze() {
         insights_check_missing_fallback "$so_json" "$so_name" "$so_namespace" "$all_namespaces"
         
         # Show progress
-        ((analyzed_count++))
+        analyzed_count=$((analyzed_count+1))
         if [[ $((analyzed_count % 3)) -eq 0 ]]; then
             printf "."
         fi


### PR DESCRIPTION
### Failure:
```
$ kubectl kedify insights
 _           _       _     _
(_)_ __  ___(_) __ _| |__ | |_ ___
| | '_ \/ __| |/ _` | '_ \| __/ __|
| | | | \__ \ | (_| | | | | |_\__ \
|_|_| |_|___/_|\__, |_| |_|\__|___/
               |___/

Analyzing ScaledObjects in namespace 'default' for potential issues .Failed at 285: ((analyzed_count++))
```

bash version:
```
$ bash --version
GNU bash, version 5.2.37(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

### Reason:
with newer bash, the `((var++))` has a bit of a counterintuitive evaluation behavior. The arithmetic expressions return exit code based on what they evaluate to, e.g.
```
$ ((0)); echo $?
1

$ ((1)); echo $?
0

$ ((2)); echo $?
0
```

because `var++` is post-increment, the exit code returns the value before expression evaluation
```
$ abc=0; ((abc++)); echo $?
1

$ abc=0; ((++abc)); echo $?
0
```

using the more explicit assignment instead of increment expression doesn't suffer from this quirky behavior because the exit code is from evaluating if the assignment succeeded or not, which is imho a lot safer.
```
$ abc=0
$ abc=$((abc+1))
$ echo $?
0

$ abc=-1
$ abc=$((abc+1))
$ echo $?
0
```